### PR TITLE
Add video autoplay option, fix playback time discrepancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ How to use:
     ],
     type: "video",
     caption: '<h4>Monsters Inc.</h4>',
-    width: 800, // required
-    height: 600, // required
+    width: 800, // Required
+    height: 600, // Required
+    autoplay: true, // Optional: Autoplay video when the lightbox opens
   }
 ]
 ```
@@ -302,7 +303,8 @@ The Icon used for videos
 
 ### Events
 
-- `onOpened(value)`: `true` to emit when the lightbox is opened and `false` when it is closed.
+- `onOpened`: Emit when the lightbox is opened.
+- `onClosed`: Emit when the lightbox is closed.
 - `onLastIndex`: Emit when the current image is the last one of the list.
 - `onFirstIndex`: Emit when the current image is the first one of the list.
 - `onStartIndex`: Emit when the current image is at the `startAt` index (specified in the properties).

--- a/specs/LightBox.spec.js
+++ b/specs/LightBox.spec.js
@@ -12,6 +12,48 @@ describe('LightBox', () => {
     test('does not render the container div', () => {
       expect(wrapper.find('.vue-lb-container').exists()).toBe(false)
     })
+
+    describe('onLightBoxOpen', () => {
+      wrapper.vm.onLightBoxOpen()
+
+      test('emits onOpened', () => {
+        expect(wrapper.emitted().onOpened).toBeTruthy()
+      })
+
+      test('adds the no-scroll class to the html element', () => {
+        expect(document.querySelector('html').classList.contains('no-scroll')).toBe(true)
+      })
+
+      test('adds the vue-lb-open class to the body element', () => {
+        expect(document.querySelector('body').classList.contains('vue-lb-open')).toBe(true)
+      })
+    })
+
+    describe('onLightBoxClose', () => {
+      wrapper.vm.onLightBoxClose()
+
+      test('emits onClosed', () => {
+        expect(wrapper.emitted().onClosed).toBeTruthy()
+      })
+    })
+
+    describe('onToggleLightBox(true)', () => {
+      wrapper.vm.onLightBoxOpen = jest.fn()
+      wrapper.vm.onToggleLightBox(true)
+
+      test('calls onLightBoxOpen', () => {
+        expect(wrapper.vm.onLightBoxOpen).toHaveBeenCalled()
+      })
+    })
+
+    describe('onToggleLightBox()', () => {
+      wrapper.vm.onLightBoxClose = jest.fn()
+      wrapper.vm.onToggleLightBox()
+
+      test('calls onLightBoxClose', () => {
+        expect(wrapper.vm.onLightBoxClose).toHaveBeenCalled()
+      })
+    })
   })
 
   describe('given one item in the media array', () => {

--- a/src/components/LightBox.vue
+++ b/src/components/LightBox.vue
@@ -34,6 +34,7 @@
               controls
               :width="media[select].width"
               :height="media[select].height"
+              :autoplay="media[select].autoplay"
             >
               <source
                 v-for="source in media[select].sources"
@@ -338,28 +339,40 @@ export default {
   },
 
   methods: {
-    onToggleLightBox(value) {
+    onLightBoxOpen() {
+      this.$emit('onOpened')
+
       if (this.disableScroll) {
-        if (value) {
-          document.querySelector('html').classList.add('no-scroll')
-        } else {
-          document.querySelector('html').classList.remove('no-scroll')
-        }
+        document.querySelector('html').classList.add('no-scroll')
       }
 
-      if (value) {
-        document.querySelector('body').classList.add('vue-lb-open')
-      } else {
-        document.querySelector('body').classList.remove('vue-lb-open')
+      document.querySelector('body').classList.add('vue-lb-open')
+      document.addEventListener('keydown', this.addKeyEvent)
+
+      if (this.$refs.video && this.$refs.video.autoplay) {
+        this.$refs.video.play()
+      }
+    },
+
+    onLightBoxClose() {
+      this.$emit('onClosed')
+
+      if (this.disableScroll) {
+        document.querySelector('html').classList.remove('no-scroll')
       }
 
-      this.$emit('onOpened', value)
+      document.querySelector('body').classList.remove('vue-lb-open')
+      document.removeEventListener('keydown', this.addKeyEvent)
 
-      if (value) {
-        document.addEventListener('keydown', this.addKeyEvent)
-      } else {
-        document.removeEventListener('keydown', this.addKeyEvent)
+      if (this.$refs.video) {
+        this.$refs.video.pause()
+        this.$refs.video.currentTime = '0'
       }
+    },
+
+    onToggleLightBox(value) {
+      if (value) this.onLightBoxOpen()
+      else this.onLightBoxClose()
     },
 
     showImage(index) {


### PR DESCRIPTION
1. Video wasn't starting at 0 when the lightbox was closed and reopened. Fixed it to match behavior on clicking prev, next.
2. Added option to autoplay video on lightbox open.
3. Add event onClosed.

Copied @mrinalini-m 's PR from here: https://github.com/pexea12/vue-image-lightbox/pull/87